### PR TITLE
Use type=email on input field

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -16,7 +16,7 @@ html
         .content
           .information
             form(method="POST", action="/invite")#join-form.form
-              input(type="text", name="email", placeholder="#{__('ENTER_EMAIL')}")#slack-email.field
+              input(type="email", name="email", placeholder="#{__('ENTER_EMAIL')}")#slack-email.field
               if tokenRequired
                 input(type="text", name="token", placeholder="#{__('ENTER_TOKEN')}")#slack-token.field
               input(type="submit", value="Join").submit


### PR DESCRIPTION
Browsers will fallback automatically to text if the type is unrecognized. Mobile browsers (iPhone or Android for instance) will display a keyboard which is easier to write emails than the regular one (all lowercase by default, `@` character present on the keyboard).
