### PR TITLE
fix: declare node version for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "node ./bin/www"
   },
+  "engines": {
+    "node": "6.11.1"
+  },
   "dependencies": {
     "body-parser": "^1.14.0",
     "cookie-parser": "^1.4.0",


### PR DESCRIPTION
Added an explicit declaration of the node version in order to apply the fix of the [recent high-severity vulnerability](https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/).

Decided to use the default version [recommended by Heroku](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version).

Would it be better to add a comment, e.g. `// change to use different safe version (4.8.4, 7.10.1, or 8.1.4)`, maybe also including a link to the communication `// https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/`, or do you think this is overkill?

Thanks, still learning how to do useful contributions : )