### PR TITLE
add support for ic.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Inspired by
 [How I hacked Slack into a community platform with Typeform](https://levels.io/slack-typeform-auto-invite-sign-ups/)
 and Socket.io's Slack page.
 
-This project supports Heroku, Azure, Cloud Foundry, and Amazon Web Services (AWS).
+This project supports Heroku, Azure, Cloud Foundry, Amazon Web Services (AWS), and [ic.dev](https://ic.dev).
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)
+[![Deploy to Azure](https://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)
 
 ## Settings
 
@@ -80,6 +80,20 @@ Instead of editing `config.js`, take these steps:
     * `S3PrefixArtifacts`: the prefix to use within that S3 bucket for all deployment artifacts written
 3. Run `aws/deploy.sh` to create the CloudFormation stack and deploy your application, outputting the URL
 4. (Optional) For a friendlier URL, log into the AWS web console and establish a custom domain pointing to the API Gateway stage deployed in step 3.
+
+### [ic.dev](https://ic.dev)
+
+If you haven't already installed the IC CLI, please refer to the [documentation](https://docs.ic.dev/setup-and-usage).
+
+Deploy the `lsuss.slack_inviter` brick directly from the IC Public Index:
+```shell
+$ ic aws up lsuss.slack_inviter slack_inviter --params community_name='Your Community Name',slack_url=yourcommunity.slack.com,slack_token=xoxp-xxx-xxx-xxx-xxx
+```
+
+Retreive the id and url of the API:
+```shell
+$ ic aws value slack_inviter
+```
 
 ## Run
 [Node.js](http://nodejs.org/) is required.

--- a/aws/brick/.gitignore
+++ b/aws/brick/.gitignore
@@ -1,0 +1,2 @@
+lambda.zip
+build/

--- a/aws/brick/brick.yaml
+++ b/aws/brick/brick.yaml
@@ -1,0 +1,10 @@
+name: lsuss.slack_inviter
+version: v0.1.2
+license: MIT
+description: |
+  A serverless web application to invite users into your Slack
+main: :brick
+require:
+  iclab.simple: v0.2.0
+assets:
+- lambda.zip

--- a/aws/brick/build.sh
+++ b/aws/brick/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# "set -e" makes it so if any step fails, the script aborts:
+set -e
+
+cd "${BASH_SOURCE%/*}"
+
+# Build Lambda package
+rm -rf build
+mkdir build
+cd ../..
+cp -r app.js config.js lib locales package-lock.json package.json public routes views aws/brick/build
+cd aws/brick/build
+cp ../../src/* .
+npm install
+npm install aws-serverless-express
+cd ../build
+zip -r ../lambda.zip .

--- a/aws/brick/index.ic
+++ b/aws/brick/index.ic
@@ -1,0 +1,36 @@
+from iclab import simple
+from . import assets
+
+
+@resource
+def brick(
+    community_name,
+    slack_url,
+    slack_token,
+    invite_token="",
+    recaptcha_site_key="",
+    recaptcha_secret_key="",
+    locale="en",
+):
+    api = simple.api("api", "express", "0.1.2")
+    func = simple.function(
+        "func",
+        "nodejs8.10",
+        assets["lambda.zip"],
+        handler="lambda.handler",
+        memory_size=1024,
+        timeout=10,
+        environ=dict(
+            COMMUNITY_NAME=community_name,
+            SLACK_URL=slack_url,
+            SLACK_TOKEN=slack_token,
+            INVITE_TOKEN=invite_token,
+            RECAPTCHA_SITE=recaptcha_site_key,
+            RECAPTCHA_SECRET=recaptcha_secret_key,
+            LOCALE=locale,
+        ),
+    )
+    func.http(api, "any", "/{proxy+}", binary_media="*/*")
+    func.http(api, "any", "/", binary_media="*/*")
+
+    return dict(api=dict(id=api["api"]["ref"], url=f'{api["url"]}/'))

--- a/aws/brick/params.icp
+++ b/aws/brick/params.icp
@@ -1,0 +1,7 @@
+community_name = "Your Community Name"
+slack_url = "yourcommunity.slack.com"
+slack_token = "xoxp-xxx-xxx-xxx-xxx"
+# invite_token = util.sensitive("")
+# recaptcha_site_key = util.sensitive("")
+# recaptcha_secret_key = util.sensitive("")
+# locale = "en"


### PR DESCRIPTION
Hi there,

A few weeks ago, we released a new open-sourced project to ease AWS deployments. It’s called [ic.dev](https://ic.dev). We used your awesome project for our Slack channel. Then we wondered why not publishing your project as a standalone brick to the IC Public Index. Here is the pull-request with the  IC code for the brick and the deployment instructions. For now, the brick is published under `lsuss.slack_inviter`, however, feel free to republish it under your name.

PS1: With this brick, your users don’t even have to have Node, NPM or anything else. They just `ic up` the brick as shown in the `README.md`.
PS2: We are available via [slack.ic.dev](https://slack.ic.dev) :slightly_smiling_face: if you need any help.