### PR TITLE
Do not leak internal error messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,13 +60,14 @@ if (app.get('env') === 'development') {
 
 // production error handler
 // no stacktraces leaked to user
+// message suppressed if Internal
 app.use(function(err, req, res, next) {
-    res.status(err.status || 500);
+    let code = err.status || 500;
+    res.status(code);
     res.render('error', {
-        message: err.message,
+        message: code === 500 ? 'Internal error' : err.message,
         error: {}
     });
 });
-
 
 module.exports = app;


### PR DESCRIPTION
We suppress back-traces, but we should also supress error messages
if the error code is 500.