### PR TITLE
Upgrade AWS SAM deploy from Node.js v8.10 to v10.x

### DIFF
--- a/aws/sam-template.json
+++ b/aws/sam-template.json
@@ -52,7 +52,7 @@
 				"Description": "Express API handler",
 				"CodeUri": "build/",
 				"Handler": "lambda.handler",
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs10.x",
 				"MemorySize": 1024,
 				"Timeout": 10,
 				"Tracing": "Active",


### PR DESCRIPTION
**Node v8 reaches EOL 12/31/2019. AWS announced they will no longer allow customers to create new Node v8 functions beginning 01/06/2020.**

The AWS Lambda runtime for Node v8 was named "nodejs8.10". The new Node v10 runtime is named "nodejs10.x". I successfully deployed and tested your slack-invite-automation code using the new Node 10 runtime for each of our local tech community Slack groups. Very simple update.

Thank you for continuing to maintain this package. We ❤️ the badge.svg feature because we can easily display active/total users from various local Slack groups. 😄