### PR TITLE
Change how invite app works to work around Slack API limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ There are two ways to issue the access token.
 
     ![](screenshots/oauth2.gif)
 
-1. In "OAuth & Permissions" page, select `admin` scope under "Permission Scopes" menu and save changes.
+1. In "OAuth & Permissions" page, select `chat:write` scope under "Permission Scopes" menu and save changes.
 
     ![](screenshots/oauth3.gif)
 
@@ -156,19 +156,21 @@ There are two ways to issue the access token.
 
     ![](screenshots/oauth4.gif)
 
-1. Visit <https://slack.com/oauth/authorize?&client_id=CLIENT_ID&team=TEAM_ID&install_redirect=install-on-team&scope=admin+client> in your browser and authorize your app.
-    * This form requires the `client` permission. Otherwise, you can see `{"ok":false,"error":"missing_scope","needed":"client","provided":"admin"}` error.
-    * Your `TEAM_ID` is the subdomain for your slack team, e.g. myteam.slack.com - your TEAM_ID is `myteam`.
-    * Your `CLIENT_ID` found in "Basic Information" section for your App.
-    * You will be shown a `Installed App Settings > OAuth Tokens for Your Team` screen.
-    * You can test auto invites with curl by providing the `OAuth Access Token`.
-    ```sh
-    curl -X POST 'https://myteam.slack.com/api/users.admin.invite' \
-   --data 'email=test@email.com&token=OAuthAccessToken&set_active=true' \
-   --compressed
-   ```
 
-    ![](screenshots/basic_info-client_id.png)
+## Slack Channel Id
+Since Slack no longer allows access to the invitation API endpoint unless you are on a enterprise setup the easiest way forward is to message a workspace admin and have them manually invite people. To ease this we let our webapp post a message into a Direct Message to an admin, or to a admin-shared channel.
+
+### Single admin
+To find out you channelId for a workspace admin DM. Open the profile of this admin in slack. Press the more button (…), then "Copy member ID". Set this value in your environment variable: `SLACK_CHANNEL`.
+If this is no longer up to date, [maybe this help post can help you out:](https://slack.com/help/articles/360003827751-Create-a-link-to-a-members-profile-)
+
+
+### Admin-invite-channel
+***Don't forget to invite your admin-user to the admin-channel***
+
+Create or use an existing admin-channel with relevant workspace admins included. In the slack client, open the channel, click the downfacing chevron next to the channel name. Next scroll all the way down in the about tab, then copy the Channel ID. Set this value in your environment variable: `SLACK_CHANNEL`
+If this is no longer up to date, [maybe this help post can help you out:](https://www.wikihow.com/Find-a-Channel-ID-on-Slack-on-PC-or-Mac)
+
 
 ## Badge
 

--- a/app.json
+++ b/app.json
@@ -8,6 +8,10 @@
       "description": "Your team name",
       "value": "YOUR TEAM NAME"
     },
+    "SLACK_CHANNEL": {
+      "description": "Your slack admin channel or admin userId (ex: C8F1JAG61)",
+      "value": "YOUR-CHANNEL-ID"
+    },
     "SLACK_URL": {
       "description": "Your slack url(ex: socketio.slack.com)",
       "value": "YOUR-TEAM.slack.com"

--- a/aws/brick/index.ic
+++ b/aws/brick/index.ic
@@ -6,6 +6,7 @@ from . import assets
 def brick(
     community_name,
     slack_url,
+    slack_channel,
     slack_token,
     invite_token="",
     recaptcha_site_key="",
@@ -22,6 +23,7 @@ def brick(
         timeout=10,
         environ=dict(
             COMMUNITY_NAME=community_name,
+            SLACK_CHANNEL=slack_channel,
             SLACK_URL=slack_url,
             SLACK_TOKEN=slack_token,
             INVITE_TOKEN=invite_token,

--- a/aws/brick/params.icp
+++ b/aws/brick/params.icp
@@ -1,5 +1,6 @@
 community_name = "Your Community Name"
 slack_url = "yourcommunity.slack.com"
+slack_channel = "ABCD10EFG"
 slack_token = "xoxp-xxx-xxx-xxx-xxx"
 # invite_token = util.sensitive("")
 # recaptcha_site_key = util.sensitive("")

--- a/aws/config.example.sh
+++ b/aws/config.example.sh
@@ -7,9 +7,9 @@ S3PrefixArtifacts=cloudformation/slack-invite-automation
 
 CommunityName="Your Community Name"
 SlackUrl=yourcommunity.slack.com
+SlackChannel=ABCD10EFG
 SlackToken=xoxp-xxx-xxx-xxx-xxx
 InviteToken=
 RecaptchaSiteKey=
 RecaptchaSecretKey=
 Locale=en
-

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -38,6 +38,7 @@ aws cloudformation deploy \
 	--parameter-overrides \
 	CommunityName="${CommunityName}" \
 	SlackUrl="${SlackUrl}" \
+	SlackChannel="${SlackChannel}" \
 	SlackToken="${SlackToken}" \
 	InviteToken="${InviteToken}" \
 	RecaptchaSiteKey="${RecaptchaSiteKey}" \

--- a/aws/sam-template.json
+++ b/aws/sam-template.json
@@ -11,6 +11,10 @@
 			"Type": "String",
 			"Description": "URL host for your Slack community (e.g., \"exampleteam.slack.com\")"
 		},
+		"SlackChannel": {
+			"Type": "String",
+			"Description": "Your slack admin channel or admin userId (e.g., \"C8F1JAG61\")"
+		},
 		"SlackToken": {
 			"Type": "String",
 			"NoEcho": true,
@@ -61,6 +65,7 @@
 					"Variables": {
 						"COMMUNITY_NAME": { "Ref": "CommunityName" },
 						"SLACK_URL": { "Ref": "SlackUrl" },
+						"SLACK_CHANNEL": { "Ref": "SlackChannel" },
 						"SLACK_TOKEN": { "Ref": "SlackToken" },
 						"INVITE_TOKEN": { "Ref": "InviteToken" },
 						"RECAPTCHA_SITE": { "Ref": "RecaptchaSiteKey" },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -45,6 +45,9 @@
         "slackUrl": {
             "type": "string"
         },
+        "slackChannel": {
+            "type": "string"
+        },
         "slackToken": {
             "type": "string"
         },
@@ -134,6 +137,7 @@
                     "properties": {
                         "COMMUNITY_NAME": "[parameters('communityName')]",
                         "SLACK_URL": "[parameters('slackUrl')]",
+                        "SLACK_CHANNEL": "[parameters('slackChannel')]",
                         "SLACK_TOKEN": "[parameters('slackToken')]",
                         "INVITE_TOKEN": "[parameters('inviteToken')]",
                         "RECAPTCHA_SITE": "[parameters('recaptchaSite')]",

--- a/config.js
+++ b/config.js
@@ -3,6 +3,11 @@ module.exports = {
   community: process.env.COMMUNITY_NAME || 'YOUR-TEAM-NAME',
   // your slack team url (ex: socketio.slack.com)
   slackUrl: process.env.SLACK_URL || 'YOUR-TEAM.slack.com',
+  // This is the member ID of an admin, or a admin-dedicated channel id.
+  // see https://github.com/outsideris/slack-invite-automation#slack-channel-id
+  // If you have one single admin, a DM will be created from your non-owner admin user.
+  // If you have a admin or invite channel, admins should be there and take manual action on these messages.
+  slackChannel: process.env.SLACK_CHANNEL || 'YOUR-SLACK-CHANNEL-ID',
   // access token of slack
   // see https://github.com/outsideris/slack-invite-automation#issue-token
   //

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,6 +12,9 @@ applications:
     # your slack team url (ex: socketio.slack.com)
     SLACK_URL: socketio.slack.com
 
+    # your slack workspace admin user id or admin channel id
+    SLACK_CHANNEL: '<channelid>'
+
     # access token of slack
     # You can generate it in https://api.slack.com/web#auth
     # You should generate the token in admin user, not owner.
@@ -25,5 +28,5 @@ applications:
 
     # an optional security measure - if it is set, then that token will be required to get invited.
     # INVITE_TOKEN: <token>
-    
+
     LOCALE: en

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,17 +23,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
       "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
     },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -68,35 +57,10 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -109,15 +73,6 @@
       "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
       "requires": {
         "safe-buffer": "5.1.1"
-      }
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "body-parser": {
@@ -166,11 +121,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -195,19 +145,6 @@
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         }
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "requires": {
-        "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
@@ -252,23 +189,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
     },
     "csextends": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.2.0.tgz",
       "integrity": "sha512-S/8k1bDTJIwuGgQYmsRoE+8P+ohV32WhQ0l4zqrc0XDdxOhjQQD7/wTZwCzoZX53jSX3V/qwjT+OkPTxWQcmjg=="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "debug": {
       "version": "3.1.0",
@@ -282,11 +214,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -314,15 +241,6 @@
       "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
       "requires": {
         "typechecker": "^2.0.8"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "~0.1.0"
       }
     },
     "editions": {
@@ -463,11 +381,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
     "extendr": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.1.0.tgz",
@@ -498,21 +411,6 @@
         }
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -542,21 +440,6 @@
         }
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -571,14 +454,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "6.0.4",
@@ -597,20 +472,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -628,16 +489,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "i18n": {
@@ -728,52 +579,10 @@
         "has": "^1.0.1"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
     "js-stringify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -910,6 +719,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -917,11 +731,6 @@
       "requires": {
         "abbrev": "1"
       }
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -968,11 +777,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -1175,11 +979,6 @@
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
       "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM="
     },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -1205,33 +1004,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
-      }
     },
     "resolve": {
       "version": "1.8.1",
@@ -1361,22 +1133,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
       "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
-    "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -1395,28 +1151,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
       "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
-    },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "requires": {
-        "punycode": "^1.4.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
     },
     "type-is": {
       "version": "1.6.16",
@@ -1465,11 +1199,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
     "validator": {
       "version": "3.43.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
@@ -1479,16 +1208,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "void-elements": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   "dependencies": {
     "body-parser": "^1.18.0",
     "cookie-parser": "^1.4.0",
+    "cross-fetch": "^3.1.4",
     "debug": "^3.1.0",
     "dotenv": "^5.0.1",
     "express": "^4.13.0",
     "i18n": "^0.8.3",
     "morgan": "^1.6.0",
     "pug": "^2.0.0-rc.4",
-    "request": "^2.62.0",
-    "serve-favicon": "^2.3.0",
-    "sanitize": "^2.1.0"
+    "sanitize": "^2.1.0",
+    "serve-favicon": "^2.3.0"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const request = require('request');
+const fetch = require('cross-fetch');
 
 const config = require('../config');
 const { badge } = require('../lib/badge');
@@ -16,48 +16,67 @@ router.get('/', function(req, res) {
 
 router.post('/invite', function(req, res) {
   if (req.body.email && (!config.inviteToken || (!!config.inviteToken && req.body.token === config.inviteToken))) {
-    function doInvite() {
-      request.post({
-          url: 'https://'+ config.slackUrl + '/api/users.admin.invite',
-          form: {
-            email: req.body.email,
-            token: config.slacktoken,
-            set_active: true
+    async function doInvite() {
+      const email = req.body.email;
+      const channelId = config.slackChannel;
+      const body = {
+        "channel": channelId,
+        "blocks": [
+          {
+              "type": "section",
+              "text": {
+                  "type": "mrkdwn",
+                  "text": `:eyes::wave:  *${email}* :wave::eyes:`
+              }
+          },
+          {
+              "type": "section",
+              "text": {
+                  "type": "mrkdwn",
+                  "text": `A person with email \`${email}\` has requested to join your workspace. Copy next message and post it to invite that person`
+              }
+          },
+          {
+              "type": "section",
+              "text": {
+                  "type": "mrkdwn",
+                  "text": `\`/invite ${email}\``
+              }
           }
-        }, function(err, httpResponse, body) {
-          // body looks like:
-          //   {"ok":true}
-          //       or
-          //   {"ok":false,"error":"already_invited"}
-          if (err) { return res.send('Error:' + err); }
-          body = JSON.parse(body);
-          if (body.ok) {
-            res.render('result', {
-              community: config.community,
-              message: 'Success! Check &ldquo;'+ req.body.email +'&rdquo; for an invite from Slack.'
-            });
-          } else {
-            let error = body.error;
-            if (error === 'already_invited' || error === 'already_in_team') {
-              res.render('result', {
-                community: config.community,
-                message: 'Success! You were already invited.<br>' +
-                        'Visit <a href="https://'+ config.slackUrl +'">'+ config.community +'</a>'
-              });
-              return;
-            } else if (error === 'invalid_email') {
-              error = 'The email you entered is an invalid email.';
-            } else if (error === 'invalid_auth') {
-              error = 'Something has gone wrong. Please contact a system administrator.';
-            }
-
-            res.render('result', {
-              community: config.community,
-              message: 'Failed! ' + error,
-              isFailed: true
-            });
+        ]
+      };
+      const url = 'https://'+ config.slackUrl + '/api/chat.postMessage';
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json;charset=utf-8",
+            "Authorization": `Bearer ${config.slacktoken}`
           }
         });
+        if(response.ok) {
+          const data = await response.json();
+          if (data.ok) {
+            res.render('result', {
+              community: config.community,
+              message: "Your email &ldquo;" + req.body.email + "&rdquo; has been sent to our admin for invite. Keep a look out in your inbox for an invitation."
+            });
+          } else {
+            console.error(data);
+            throw new Error('Non-ok response')
+          }
+        }
+      } catch(err) {
+        console.error(err);
+        error = 'Something has gone wrong. Please try again at a later time.';
+        res.render('result', {
+          community: config.community,
+          message: 'Failed! ' + error,
+          isFailed: true
+        });
+
+      }
     }
     if (!!config.recaptchaSiteKey && !!config.recaptchaSecretKey) {
       request.post({


### PR DESCRIPTION
Since Slack no longer allows access to the invitation API endpoint unless you are on an enterprise setup the easiest way forward is to message a workspace admin and have them manually invite people. To ease this we let our web app post a message into a Direct Message to an admin, or to a admin-shared channel.

This approach is in use by me at least. Take this if you wan't. Until Slack changes their mind it can at least be good workaround for others.

Note 1: I've changed out the library `request` to use `cross-fetch` instead since `request` is deprecated since 2019.
Note 2: The old approach might still be valid for enterprise setups, but so is this approach, but less automated.
Note 3: I've blindly edited all the configuration files, following existing patterns, since I do not know how to test all of them.